### PR TITLE
Broken links in readme & infinite loop in px_uploader.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ The appropriated and ready to use binaries are uploaded here: [PX4](https://gith
 For PX4 DroneCAN you can upload the firmware by typing the following 2 lines:
 
 ```bash
-wget https://github.com/ZilantRobotics/PX4-Autopilot/releases/download/v1.13.0_dronecan_hitl/px4_fmu-v5_default.px4
+wget https://github.com/ZilantRobotics/PX4-Autopilot/releases/download/v1.13.0_hitl/px4_fmu-v5_default.px4
 ./scripts/px4/upload.sh px4_fmu-v5_default.px4
 ```
 
 For PX4 Cyphal you can upload the firmware by typing:
 
 ```bash
-wget https://github.com/ZilantRobotics/PX4-Autopilot/releases/download/v1.13.0_cyphal_hitl/px4_fmu-v5_default.px4
-./scripts/px4/upload.sh px4_fmu-v5_default.px4
+wget https://github.com/ZilantRobotics/PX4-Autopilot/releases/download/v1.13.0_hitl/px4_fmu-v5_cyphal.px4
+./scripts/px4/upload.sh px4_fmu-v5_cyphal.px4
 ```
 
 **Step 5. Configure autopilot**

--- a/scripts/px4/px_uploader.py
+++ b/scripts/px4/px_uploader.py
@@ -794,6 +794,10 @@ def main():
     parser.add_argument('--use-protocol-splitter-format', action='store_true', help='use protocol splitter format for reboot')
     parser.add_argument('firmware', action="store", nargs='+', help="Firmware file(s)")
     args = parser.parse_args()
+    
+    for fw in args.firmware:
+        if not os.path.exists(fw):
+            raise ValueError(f"Firmware file {fw} does not exist!")
 
     if args.use_protocol_splitter_format:
         print("Using protocol splitter format to reboot pixhawk!")


### PR DESCRIPTION
There were couple of broken links in the Step 4 of the README

Also, px_uploade.py went into an infinite loop if provided with firmware name that does not exist. With this changes uploader explicitly fails and informs the user if the firmware name is invalid.